### PR TITLE
fix(deps): remaining minor/patch bumps

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -20,7 +20,7 @@ jobs:
       # Example: https://github.com/opentripplanner/OpenTripPlanner/actions/runs/4490450225/jobs/7897533439
       - uses: actions/setup-node@v6.4.0
         with:
-          node-version: 24.14.0
+          node-version: 24.16.0
       - uses: actions/setup-java@v5.3.0
         with:
           java-version: 21.0.1+12

--- a/pom.xml
+++ b/pom.xml
@@ -26,9 +26,9 @@
 
         <spring-cloud-gcp-dependencies.version>8.0.4</spring-cloud-gcp-dependencies.version>
         <net.datafaker.version>2.5.4</net.datafaker.version>
-        <testcontainers-bom.version>2.0.3</testcontainers-bom.version>
+        <testcontainers-bom.version>2.0.5</testcontainers-bom.version>
         <jakarta-xml-bind-api.version>4.0.5</jakarta-xml-bind-api.version>
-        <jaxb-runtime.version>4.0.6</jaxb-runtime.version>
+        <jaxb-runtime.version>4.0.9</jaxb-runtime.version>
         <siri-java-model.version>2.0.6</siri-java-model.version>
         <prettier-java.version>2.1.0</prettier-java.version>
         <prettier-maven-plugin.version>0.22</prettier-maven-plugin.version>
@@ -171,7 +171,7 @@
         <dependency>
             <groupId>org.springframework.graphql</groupId>
             <artifactId>spring-graphql-test</artifactId>
-            <version>2.0.2</version>
+            <version>2.0.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Remaining minor/patch dependency bumps

Rebased onto the Spring Boot 4 master (after #145 and #146 merged). The original superpom and spring-cloud-gcp bumps are **dropped** — #145 already moved both to their higher Spring Boot 4 lines (superpom 6.4.0, gcp 8.0.4), so re-applying the 5.x/7.x versions here would have been a downgrade.

### Remaining bumps
| Dependency | From | To |
|---|---|---|
| `testcontainers-bom` | 2.0.3 | 2.0.5 |
| `jaxb-runtime` | 4.0.6 | 4.0.9 |
| `spring-graphql-test` | 2.0.2 | 2.0.4 |
| CI `node` | 24.14.0 | 24.16.0 |

### Verification
- `./mvnw clean verify` passes locally with `CI=true` on Spring Boot 4.0.6 (prettier check, unit + Firestore testcontainer tests, JaCoCo coverage met).