### PR TITLE
feat(deps)!: upgrade to Spring Boot 4.x (superpom 6 + helpers 7 + gcp 8)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.entur.ror</groupId>
         <artifactId>superpom</artifactId>
-        <version>5.3.0</version>
+        <version>6.4.0</version>
     </parent>
 
     <groupId>org.entur</groupId>
@@ -22,9 +22,9 @@
     <properties>
         <java.version>21</java.version>
 
-        <entur.helpers.version>5.50.0</entur.helpers.version>
+        <entur.helpers.version>7.1.0</entur.helpers.version>
 
-        <spring-cloud-gcp-dependencies.version>7.4.5</spring-cloud-gcp-dependencies.version>
+        <spring-cloud-gcp-dependencies.version>8.0.4</spring-cloud-gcp-dependencies.version>
         <net.datafaker.version>2.5.4</net.datafaker.version>
         <testcontainers-bom.version>2.0.3</testcontainers-bom.version>
         <jakarta-xml-bind-api.version>4.0.5</jakarta-xml-bind-api.version>
@@ -172,6 +172,21 @@
             <groupId>org.springframework.graphql</groupId>
             <artifactId>spring-graphql-test</artifactId>
             <version>2.0.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-graphql-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-resttestclient</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-restclient</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/org/entur/enlil/security/EnlilSecurityConfiguration.java
+++ b/src/main/java/org/entur/enlil/security/EnlilSecurityConfiguration.java
@@ -13,7 +13,6 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.oauth2.server.resource.authentication.JwtIssuerAuthenticationManagerResolver;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.stereotype.Component;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
@@ -39,15 +38,15 @@ public class EnlilSecurityConfiguration {
       .csrf(csrf -> csrf.ignoringRequestMatchers("/siri"))
       .authorizeHttpRequests(auth ->
         auth
-          .requestMatchers(AntPathRequestMatcher.antMatcher("/actuator/prometheus"))
+          .requestMatchers("/actuator/prometheus")
           .permitAll()
-          .requestMatchers(AntPathRequestMatcher.antMatcher("/actuator/health"))
+          .requestMatchers("/actuator/health")
           .permitAll()
-          .requestMatchers(AntPathRequestMatcher.antMatcher("/actuator/health/liveness"))
+          .requestMatchers("/actuator/health/liveness")
           .permitAll()
-          .requestMatchers(AntPathRequestMatcher.antMatcher("/actuator/health/readiness"))
+          .requestMatchers("/actuator/health/readiness")
           .permitAll()
-          .requestMatchers(AntPathRequestMatcher.antMatcher("/siri"))
+          .requestMatchers("/siri")
           .permitAll()
           .anyRequest()
           .authenticated()

--- a/src/main/java/org/entur/enlil/security/EnlilSecurityConfiguration.java
+++ b/src/main/java/org/entur/enlil/security/EnlilSecurityConfiguration.java
@@ -33,7 +33,7 @@ public class EnlilSecurityConfiguration {
   public SecurityFilterChain filterChain(
     HttpSecurity http,
     AuthenticationManagerResolver<HttpServletRequest> authenticationManagerResolver
-  ) throws Exception {
+  ) {
     return http
       .csrf(csrf -> csrf.ignoringRequestMatchers("/siri"))
       .authorizeHttpRequests(auth ->

--- a/src/main/java/org/entur/enlil/security/EnturSecurityConfiguration.java
+++ b/src/main/java/org/entur/enlil/security/EnturSecurityConfiguration.java
@@ -15,7 +15,7 @@ import org.rutebanken.helper.organisation.user.UserInfoExtractor;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientProperties;
+import org.springframework.boot.security.oauth2.client.autoconfigure.OAuth2ClientProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;

--- a/src/main/java/org/entur/enlil/security/LocalSecurityConfiguration.java
+++ b/src/main/java/org/entur/enlil/security/LocalSecurityConfiguration.java
@@ -17,7 +17,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 public class LocalSecurityConfiguration {
 
   @Bean
-  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+  public SecurityFilterChain filterChain(HttpSecurity http) {
     return http
       .csrf(AbstractHttpConfigurer::disable)
       .cors(cors -> cors.configurationSource(corsConfigurationSource()))

--- a/src/test/java/org/entur/enlil/EnlilApplicationIntegrationTests.java
+++ b/src/test/java/org/entur/enlil/EnlilApplicationIntegrationTests.java
@@ -7,8 +7,6 @@ import static org.entur.enlil.faker.EstimatedVehicleJourneyProvider.estimatedVeh
 
 import au.com.origin.snapshots.Expect;
 import au.com.origin.snapshots.junit5.SnapshotExtension;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.api.gax.core.CredentialsProvider;
 import com.google.api.gax.core.NoCredentialsProvider;
 import com.google.cloud.firestore.Firestore;
@@ -30,10 +28,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.graphql.tester.AutoConfigureGraphQlTester;
+import org.springframework.boot.graphql.test.autoconfigure.tester.AutoConfigureGraphQlTester;
+import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.context.annotation.Bean;
 import org.springframework.graphql.test.tester.GraphQlTester;
@@ -47,6 +45,8 @@ import org.testcontainers.gcloud.FirestoreEmulatorContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
 import uk.org.siri.siri21.Siri;
 
 @ExtendWith(SpringExtension.class)
@@ -104,8 +104,10 @@ class EnlilApplicationIntegrationTests {
   }
 
   @AfterEach
-  void clearFirestoreEmulator() {
-    firestore.recursiveDelete(firestore.collection("codespaces"));
+  void clearFirestoreEmulator() throws ExecutionException, InterruptedException {
+    // Await completion so the emulator is fully cleared before the next test runs,
+    // otherwise the deletion races subsequent tests and leaks data across them.
+    firestore.recursiveDelete(firestore.collection("codespaces")).get();
   }
 
   @Test


### PR DESCRIPTION
## Bucket 1 of the dependency sweep — high-risk Spring Boot 4.x upgrade

⚠️ **Major upgrade.** These three majors are all tied to Spring Boot 4 and **must move together** — superpom 6 brings Spring Boot 4.0.6, helpers 7 is built on superpom 6.1.0, and spring-cloud-gcp 8 is the Spring Boot 4-aligned line (7.x is Spring Boot 3-only).

### Dependency bumps
| Dependency | From | To | Notes |
|---|---|---|---|
| `org.entur.ror:superpom` | 5.3.0 | 6.4.0 | Spring Boot 3.5.6 → **4.0.6** |
| `entur.helpers.version` | 5.50.0 | 7.1.0 | built on superpom 6.1.0 (Spring Boot 4) |
| `spring-cloud-gcp-dependencies` | 7.4.5 | 8.0.4 | Spring Boot 4-aligned |

Resulting stack: **Spring Boot 4.0.6, Spring Framework 7.0.7, Spring Security 7.0.5, Jackson 3, spring-graphql 2.0.3.**

### Breaking changes addressed

**Main code**
- `EnlilSecurityConfiguration`: `AntPathRequestMatcher` was removed in Spring Security 7. Replaced with plain-string `requestMatchers(...)` (PathPattern-backed by default). Exact paths, behaviour unchanged.
- `EnturSecurityConfiguration`: `OAuth2ClientProperties` moved to `org.springframework.boot.security.oauth2.client.autoconfigure` (new dedicated Boot 4 module) — matches what helpers 7 expects.

**Tests**
- Jackson 3 is Spring Boot 4's default; the auto-configured `ObjectMapper` is now `tools.jackson.databind.ObjectMapper`. Migrated the integration test's `ObjectMapper`/`TypeReference` to the `tools.jackson` API. (App code does not use Jackson directly.)
- `TestRestTemplate` and `AutoConfigureGraphQlTester` were extracted into new modules. Added `spring-boot-resttestclient`, `spring-boot-graphql-test`, and `spring-boot-restclient` (TestRestTemplate's RestTemplate backend) as test deps; updated the moved imports.
- `clearFirestoreEmulator` now awaits `recursiveDelete().get()`. The future was previously fired-and-not-awaited; Spring Boot 4 changed JUnit method ordering, which exposed cross-test data leakage. Awaiting guarantees isolation regardless of order.

### Verification
- `./mvnw clean verify` passes locally, including with `CI=true` (prettier **check** mode): 7 tests green, JaCoCo coverage met, Firestore testcontainer integration tests pass.

### Supersedes
Renovate PRs #142 (superpom 6), #132 (helpers 7), #141 (gcp 8).

### Relationship to the rest of the sweep
The low-risk minor/patch bucket stays on Spring Boot 3.x and is handled separately. Whichever of the two lands first, the other will need a trivial `pom.xml` rebase on the shared version lines.