### PR TITLE
Restore WebClient.Builder bean for Spring Boot 4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,15 @@
             <artifactId>spring-boot-starter-graphql</artifactId>
         </dependency>
 
+        <!-- Provides the reactive WebClient autoconfiguration (WebClient.Builder bean).
+             Required by AuthorizedWebClientBuilder in EnturSecurityConfiguration.
+             In Spring Boot 4 this autoconfig moved into its own module and is no
+             longer active just because spring-webflux is transitively on the classpath. -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webflux</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-config</artifactId>


### PR DESCRIPTION
## Problem

After the Spring Boot 4 upgrade the application fails to start:

```
Parameter 0 of method internalWebClient in
org.entur.enlil.security.EnturSecurityConfiguration required a bean of type
'org.springframework.web.reactive.function.client.WebClient$Builder' that could not be found.
```

## Root cause

Spring Boot 4 modularized autoconfiguration. The reactive `WebClient.Builder`
autoconfig moved out of the monolithic `spring-boot-autoconfigure` jar into the
dedicated `spring-boot-webflux` module, and is no longer activated just because
`spring-webflux` happens to be transitively on the classpath (as it was under
Spring Boot 3).

This servlet app (`spring-boot-starter-web`) didn't depend on that module, so the
`WebClient.Builder` bean disappeared. `EnturSecurityConfiguration.internalWebClient`
— which feeds the Entur `AuthorizedWebClientBuilder` and is active under the `baba`
role-assignment extractor — could no longer be created, failing context startup.

## Fix

Add `spring-boot-starter-webflux`, which pulls in `spring-boot-webflux` (the
autoconfig module) plus `spring-webflux` and `reactor-netty`. Tomcat remains the
web stack — with both servlet and reactive on the classpath Spring Boot keeps the
servlet application type; reactor-netty is only used as the HTTP client transport,
no reactive server is started.

## Verification

`./mvnw test` — `EnlilApplicationIntegrationTests`: **5/5 pass**, context loads
cleanly past the previously failing bean.