### PR TITLE
Use spring-boot-webclient for WebClient.Builder bean

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,13 +97,15 @@
             <artifactId>spring-boot-starter-graphql</artifactId>
         </dependency>
 
-        <!-- Provides the reactive WebClient autoconfiguration (WebClient.Builder bean).
-             Required by AuthorizedWebClientBuilder in EnturSecurityConfiguration.
-             In Spring Boot 4 this autoconfig moved into its own module and is no
-             longer active just because spring-webflux is transitively on the classpath. -->
+        <!-- Provides WebClientAutoConfiguration (the WebClient.Builder bean), required by
+             AuthorizedWebClientBuilder in EnturSecurityConfiguration. In Spring Boot 4 the
+             reactive WebClient autoconfig was split into its own module and is no longer
+             active just because spring-webflux is transitively on the classpath. This module
+             pulls in spring-webflux + the reactive http-client without the full WebFlux
+             server stack (a JDK ClientHttpConnector is used as the transport). -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-webflux</artifactId>
+            <artifactId>spring-boot-webclient</artifactId>
         </dependency>
 
         <dependency>

--- a/src/test/java/org/entur/enlil/security/WebClientBuilderAvailabilityTest.java
+++ b/src/test/java/org/entur/enlil/security/WebClientBuilderAvailabilityTest.java
@@ -1,0 +1,30 @@
+package org.entur.enlil.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.http.client.autoconfigure.reactive.ReactiveHttpClientAutoConfiguration;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.boot.webclient.autoconfigure.WebClientAutoConfiguration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+/**
+ * Guards the Spring Boot 4 dependency on spring-boot-webclient. Its
+ * WebClientAutoConfiguration provides the WebClient.Builder bean that
+ * EnturSecurityConfiguration (baba role assignment extractor) requires.
+ */
+class WebClientBuilderAvailabilityTest {
+
+  @Test
+  void webClientBuilderBeanIsAutoConfigured() {
+    new ApplicationContextRunner()
+      .withConfiguration(
+        AutoConfigurations.of(
+          ReactiveHttpClientAutoConfiguration.class,
+          WebClientAutoConfiguration.class
+        )
+      )
+      .run(context -> assertThat(context).hasSingleBean(WebClient.Builder.class));
+  }
+}


### PR DESCRIPTION
spring-boot-starter-webflux only provides server-side WebFlux autoconfig, not the WebClient.Builder bean. In Spring Boot 4 that bean comes from WebClientAutoConfiguration in the spring-boot-webclient module. Swap to it and add a regression test asserting the bean is auto-configured.